### PR TITLE
Upgrade csvtojson to vers 2.x to fix lodash vulnerability

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 CarlSeiler
+Copyright (c) 2018-2019 CarlSeiler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/converter.js
+++ b/converter.js
@@ -21,10 +21,10 @@ const converter = (inputFile = './customer-data.csv',
     // Convert csv file to json file and output to disc
     csv()
         .fromFile(inputFile)
-        .on('json', (jsonObj, lineNumber) => {
+        .subscribe((jsonObj, lineNumber) => {
             outputArray.push(jsonObj);
         })
-        .on('done', (error) => {
+        .then((error) => {
 
             fs.appendFile(outputFile, JSON.stringify(outputArray, null, 2), function(err) {
                 if (err) throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,19 +4,20 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "csvtojson": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-1.1.9.tgz",
-      "integrity": "sha1-5kGucve8L6P5qvEn4CH8iUR8HNE=",
-      "requires": {
-        "lodash": "4.17.10",
-        "strip-bom": "1.0.0"
-      }
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
-    "first-chunk-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+    "csvtojson": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.8.tgz",
+      "integrity": "sha512-DC6YFtsJiA7t/Yz+KjzT6GXuKtU/5gRbbl7HJqvDVVir+dxdw2/1EgwfgJdnsvUT7lOnON5DvGftKuYWX1nMOQ==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -24,17 +25,16 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "strip-bom": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-      "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "requires": {
-        "first-chunk-stream": "1.0.0",
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "csvtojson": "1.1.9"
+    "csvtojson": "^2.0.8"
   }
 }


### PR DESCRIPTION
Old version of csvtojson depended on lodash 4.17.10, causing a need to upgrade to newer version as version 1x of csvtojson did not appear to have updated lodash. Version 2x of csvtojson required slightly different code since it had done away with callbacks on the .fromFile method.

